### PR TITLE
ENG-26 Remote Terminology Configuration

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: hapi-fhir-build-publish-image
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/task-1: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/custom-generate-build-id.yaml]"
+    pipelinesascode.tekton.dev/task-2: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/maven-custom.yaml]"
+spec:
+  params:
+    - name: git-repo-name
+      value: "{{repo_name}}"
+    - name: git-repo-url
+      value: "{{repo_url}}"
+    - name: git-revision
+      value: "{{revision}}"
+    - name: git-branch
+      value: "{{source_branch}}"
+    - name: base-version
+      value: "1.0.0"
+    - name: dockerfile
+      value: 'Dockerfile'
+    - name: container-repo
+      value: "repo-harbor.apps.dev.infra.graphitehealth.io/gh"
+    - name: maven-goals
+      type: array
+      value:
+        - "compile"
+        - "package"
+    - name: maven-image
+      value: 'repo-harbor.apps.dev.infra.graphitehealth.io/gh/java-build:latest'
+  pipelineSpec:
+    params:
+      - name: git-repo-name
+      - name: git-repo-url
+      - name: git-revision
+      - name: git-branch
+      - name: base-version
+      - name: dockerfile
+      - name: container-repo
+      - name: maven-goals
+        type: array
+      - name: maven-image
+    tasks:
+      - name: fetch-repository
+        params:
+          - name: url
+            value: $(params.git-repo-url)
+          - name: refspec
+            value: $(params.git-branch)
+          - name: revision
+            value: $(params.git-revision)
+        taskRef:
+          kind: ClusterTask
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: build
+          - name: basic-auth
+            workspace: basic-auth
+      - name: set-build-id
+        params:
+          - name: base-version
+            value: $(params.base-version)
+          - name: commit-sha
+            value: $(tasks.fetch-repository.results.commit)
+        runAfter:
+          - fetch-repository
+        taskRef:
+          name: custom-generate-build-id
+      - name: maven-build
+        params:
+          - name: GOALS
+            value:
+              - $(params.maven-goals)
+              #- dependencyCheckAnalyze
+          - name: MAVEN_IMAGE
+            value: $(params.maven-image)
+          - name: jar-version
+            value: $(tasks.set-build-id.results.build-id)
+        runAfter:
+          - set-build-id
+        taskRef:
+          name: maven-custom
+        workspaces:
+          - name: output
+            workspace: build
+          - name: maven-settings
+            workspace: maven-settings
+      - name: build-image
+        params:
+          - name: DOCKERFILE
+            value: $(params.dockerfile)
+          - name: TLSVERIFY
+            value: 'false'
+          - name: IMAGE
+            value: >-
+              $(params.container-repo)/$(params.git-repo-name):$(tasks.set-build-id.results.build-id)
+        runAfter:
+          - gradle-build
+        taskRef:
+          name: buildah-custom
+        workspaces:
+          - name: source
+            workspace: build
+    workspaces:
+      - name: build
+      - name: basic-auth
+  workspaces:
+    - name: basic-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
+    - name: build
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -90,25 +90,10 @@ spec:
             workspace: build
           - name: maven-settings
             workspace: maven-settings
-      - name: build-image
-        params:
-          - name: DOCKERFILE
-            value: $(params.dockerfile)
-          - name: TLSVERIFY
-            value: 'false'
-          - name: IMAGE
-            value: >-
-              $(params.container-repo)/$(params.git-repo-name):$(tasks.set-build-id.results.build-id)
-        runAfter:
-          - maven-build
-        taskRef:
-          name: buildah-custom
-        workspaces:
-          - name: source
-            workspace: build
     workspaces:
       - name: build
       - name: basic-auth
+      - name: maven-settings
   workspaces:
     - name: basic-auth
       secret:
@@ -121,3 +106,12 @@ spec:
           resources:
             requests:
               storage: 1Gi
+    - name: maven-settings
+      volumeClaimTemplate:
+        metadata:
+          name: hapi-graphitehealth-maven-settings-pvc
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: 50Mi

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -100,7 +100,7 @@ spec:
             value: >-
               $(params.container-repo)/$(params.git-repo-name):$(tasks.set-build-id.results.build-id)
         runAfter:
-          - gradle-build
+          - maven-build
         taskRef:
           name: buildah-custom
         workspaces:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: hapi-fhir-build-publish-image
+  name: hapi-fhir-pull-request-build
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: hapi-fhir-build-publish-image
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[push, pull_request_merged]"
+    pipelinesascode.tekton.dev/on-target-branch: "[ENG-26]"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/task-1: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/custom-generate-build-id.yaml]"
+    pipelinesascode.tekton.dev/task-2: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/maven-custom.yaml]"
+    pipelinesascode.tekton.dev/task-3: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/get-deployment-names.yaml]"
+    pipelinesascode.tekton.dev/task-4: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/buildah-custom.yaml]"
+spec:
+  params:
+    - name: git-repo-name
+      value: "{{repo_name}}"
+    - name: git-repo-url
+      value: "{{repo_url}}"
+    - name: git-revision
+      value: "{{revision}}"
+    - name: git-branch
+      value: "{{source_branch}}"
+    - name: base-version
+      value: "1.0.0"
+    - name: dockerfile
+      value: 'Dockerfile'
+    - name: container-repo
+      value: "repo-harbor.apps.dev.infra.graphitehealth.io/gh"
+    - name: maven-goals
+      type: array
+      value:
+        - "compile"
+        - "package"
+    - name: maven-image
+      value: 'repo-harbor.apps.dev.infra.graphitehealth.io/gh/java-build:latest'
+  pipelineSpec:
+    params:
+      - name: git-repo-name
+      - name: git-repo-url
+      - name: git-revision
+      - name: git-branch
+      - name: base-version
+      - name: dockerfile
+      - name: container-repo
+      - name: maven-goals
+        type: array
+      - name: maven-image
+    tasks:
+      - name: fetch-repository
+        params:
+          - name: url
+            value: $(params.git-repo-url)
+          - name: refspec
+            value: $(params.git-branch)
+          - name: revision
+            value: $(params.git-revision)
+        taskRef:
+          kind: ClusterTask
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: build
+          - name: basic-auth
+            workspace: basic-auth
+      - name: get-deployments
+        params:
+          - name: git-repo-name
+            value: $(params.git-repo-name)
+        workspaces:
+          - name: source
+            workspace: build
+        taskRef:
+          name: get-deployment-names
+        runAfter:
+          - fetch-repository
+      - name: set-build-id
+        params:
+          - name: base-version
+            value: $(params.base-version)
+          - name: commit-sha
+            value: $(tasks.fetch-repository.results.commit)
+        runAfter:
+          - fetch-repository
+        taskRef:
+          name: custom-generate-build-id
+      - name: maven-build
+        params:
+          - name: GOALS
+            value:
+              - $(params.maven-goals)
+              #- dependencyCheckAnalyze
+          - name: MAVEN_IMAGE
+            value: $(params.maven-image)
+          - name: jar-version
+            value: $(tasks.set-build-id.results.build-id)
+        runAfter:
+          - set-build-id
+        taskRef:
+          name: maven-custom
+        workspaces:
+          - name: output
+            workspace: build
+          - name: maven-settings
+            workspace: maven-settings
+      - name: build-image
+        params:
+          - name: DOCKERFILE
+            value: $(params.dockerfile)
+          - name: TLSVERIFY
+            value: 'false'
+          - name: IMAGE
+            value: >-
+              $(params.container-repo)/$(params.git-repo-name):$(tasks.set-build-id.results.build-id)
+        runAfter:
+          - gradle-build
+        taskRef:
+          name: buildah-custom
+        workspaces:
+          - name: source
+            workspace: build
+#      - name: gitops-clone
+#        params:
+#          - name: url
+#            value: git@github.com:graphitehealth/gitops.git
+#          - name: revision
+#            value: 'refs/heads/main:refs/remotes/origin/main'
+#        workspaces:
+#          - name: output
+#            workspace: build
+#        taskRef:
+#          kind: ClusterTask
+#          name: git-clone
+#        runAfter:
+#          - build-image
+#      - name: gitops-update
+#        params:
+#          - name: GIT_SCRIPT
+#            value: |
+#              git checkout -b main
+#              for i in $(tasks.get-deployments.results.deployment-names); do
+#                sed -i "/image:/{ /$(params.git-repo-name)/s/@sha256:.*/@$(tasks.build-image.results.IMAGE_DIGEST)/"} base/${i}/${i}-deploy.yaml
+#                git add base/${i}/${i}-deploy.yaml
+#                dos2unix base/${i}/${i}-deploy.yaml
+#              done
+#              msg="TektonBot Update Image Tag : $(tasks.get-deployments.results.deployment-names) ($(tasks.build-image.results.IMAGE_DIGEST))"
+#              git commit -m "${msg}"
+#              git push -u origin main
+#              echo $msg
+#          - name: GIT_USER_NAME
+#            value: "Tekton Bot"
+#          - name: GIT_USER_EMAIL
+#            value: tekton@local
+#        workspaces:
+#          - name: source
+#            workspace: build
+#        taskRef:
+#          kind: ClusterTask
+#          name: git-cli
+#        runAfter:
+#          - gitops-clone
+    workspaces:
+      - name: build
+      - name: basic-auth
+  workspaces:
+    - name: basic-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
+    - name: build
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -113,7 +113,7 @@ spec:
             value: >-
               $(params.container-repo)/$(params.git-repo-name):$(tasks.set-build-id.results.build-id)
         runAfter:
-          - gradle-build
+          - maven-build
         taskRef:
           name: buildah-custom
         workspaces:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -162,6 +162,7 @@ spec:
     workspaces:
       - name: build
       - name: basic-auth
+      - name: maven-settings
   workspaces:
     - name: basic-auth
       secret:
@@ -174,3 +175,12 @@ spec:
           resources:
             requests:
               storage: 1Gi
+    - name: maven-settings
+      volumeClaimTemplate:
+        metadata:
+          name: hapi-graphitehealth-maven-settings-pvc
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: 50Mi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hapi-fhir-build-publish-image
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push, pull_request_merged]"
-    pipelinesascode.tekton.dev/on-target-branch: "[ENG-26]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/task-1: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/custom-generate-build-id.yaml]"
     pipelinesascode.tekton.dev/task-2: "[https://github.com/graphitehealth/main-deploy/blob/main/tekton/tasks/maven-custom.yaml]"
@@ -119,46 +119,46 @@ spec:
         workspaces:
           - name: source
             workspace: build
-#      - name: gitops-clone
-#        params:
-#          - name: url
-#            value: git@github.com:graphitehealth/gitops.git
-#          - name: revision
-#            value: 'refs/heads/main:refs/remotes/origin/main'
-#        workspaces:
-#          - name: output
-#            workspace: build
-#        taskRef:
-#          kind: ClusterTask
-#          name: git-clone
-#        runAfter:
-#          - build-image
-#      - name: gitops-update
-#        params:
-#          - name: GIT_SCRIPT
-#            value: |
-#              git checkout -b main
-#              for i in $(tasks.get-deployments.results.deployment-names); do
-#                sed -i "/image:/{ /$(params.git-repo-name)/s/@sha256:.*/@$(tasks.build-image.results.IMAGE_DIGEST)/"} base/${i}/${i}-deploy.yaml
-#                git add base/${i}/${i}-deploy.yaml
-#                dos2unix base/${i}/${i}-deploy.yaml
-#              done
-#              msg="TektonBot Update Image Tag : $(tasks.get-deployments.results.deployment-names) ($(tasks.build-image.results.IMAGE_DIGEST))"
-#              git commit -m "${msg}"
-#              git push -u origin main
-#              echo $msg
-#          - name: GIT_USER_NAME
-#            value: "Tekton Bot"
-#          - name: GIT_USER_EMAIL
-#            value: tekton@local
-#        workspaces:
-#          - name: source
-#            workspace: build
-#        taskRef:
-#          kind: ClusterTask
-#          name: git-cli
-#        runAfter:
-#          - gitops-clone
+      - name: gitops-clone
+        params:
+          - name: url
+            value: git@github.com:graphitehealth/gitops.git
+          - name: revision
+            value: 'refs/heads/main:refs/remotes/origin/main'
+        workspaces:
+          - name: output
+            workspace: build
+        taskRef:
+          kind: ClusterTask
+          name: git-clone
+        runAfter:
+          - build-image
+      - name: gitops-update
+        params:
+          - name: GIT_SCRIPT
+            value: |
+              git checkout -b main
+              for i in $(tasks.get-deployments.results.deployment-names); do
+                sed -i "/image:/{ /$(params.git-repo-name)/s/@sha256:.*/@$(tasks.build-image.results.IMAGE_DIGEST)/"} base/${i}/${i}-deploy.yaml
+                git add base/${i}/${i}-deploy.yaml
+                dos2unix base/${i}/${i}-deploy.yaml
+              done
+              msg="TektonBot Update Image Tag : $(tasks.get-deployments.results.deployment-names) ($(tasks.build-image.results.IMAGE_DIGEST))"
+              git commit -m "${msg}"
+              git push -u origin main
+              echo $msg
+          - name: GIT_USER_NAME
+            value: "Tekton Bot"
+          - name: GIT_USER_EMAIL
+            value: tekton@local
+        workspaces:
+          - name: source
+            workspace: build
+        taskRef:
+          kind: ClusterTask
+          name: git-cli
+        runAfter:
+          - gitops-clone
     workspaces:
       - name: build
       - name: basic-auth

--- a/README.md
+++ b/README.md
@@ -7,7 +7,23 @@ Note that this project is specifically intended for end users of the HAPI FHIR J
 Need Help? Please see: https://github.com/hapifhir/hapi-fhir/wiki/Getting-Help
 
 ## Graphite Specific
-To enable the app to run inside IntellijIdea, open the Maven Tool Window, expand the Profiles folder, and check the `boot` item. Click the "Reload All Maven Projects button". 
+
+## Run locally in IntelliJIdea with Local Postgres DB
+* Open the Maven Tool Window, expand the Profiles folder, and check the `boot` item. 
+* Click the "Reload All Maven Projects button". 
+* In your run configuration, set the following environment variables:
+  * DB_URL = jdbc:postgresql://localhost:5432/hapi
+  * DB_USER = admin
+  * DB_PASS = admin
+  * TERMINOLOGY_URL = https://dev-pivot-app.infra.graphitehealth.io/SymedicaldevpivotFHIRServices/r4/
+
+## Run Locally with Docker Compose
+
+The first run is very slow.
+
+```
+docker compose up -d
+```
 
 ### Changes specific to the project
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Need Help? Please see: https://github.com/hapifhir/hapi-fhir/wiki/Getting-Help
 ## Graphite Specific
 
 ### Run Locally in IntelliJIdea with Local Postgres DB
+* There is a Postgres DB running on port 5432
 * Open the Maven Tool Window, expand the Profiles folder, and check the `boot` item. 
 * Click the "Reload All Maven Projects button". 
 * In your run configuration, set the following environment variables:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Note that this project is specifically intended for end users of the HAPI FHIR J
 
 Need Help? Please see: https://github.com/hapifhir/hapi-fhir/wiki/Getting-Help
 
+## Graphite Specific
+To enable the app to run inside IntellijIdea, open the Maven Tool Window, expand the Profiles folder, and check the `boot` item. Click the "Reload All Maven Projects button". 
+
+### Changes specific to the project
+
+* application.yaml
+* AppProperties (added `remote_terminology`)
+* StarterJpaConfig (uses `remote_terminoloy` setting to enable Symedical as a remote server)
+
 ## Prerequisites
 
 In order to use this sample, you should have:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Need Help? Please see: https://github.com/hapifhir/hapi-fhir/wiki/Getting-Help
 
 ## Graphite Specific
 
-## Run locally in IntelliJIdea with Local Postgres DB
+### Run Locally in IntelliJIdea with Local Postgres DB
 * Open the Maven Tool Window, expand the Profiles folder, and check the `boot` item. 
 * Click the "Reload All Maven Projects button". 
 * In your run configuration, set the following environment variables:
@@ -17,7 +17,7 @@ Need Help? Please see: https://github.com/hapifhir/hapi-fhir/wiki/Getting-Help
   * DB_PASS = admin
   * TERMINOLOGY_URL = https://dev-pivot-app.infra.graphitehealth.io/SymedicaldevpivotFHIRServices/r4/
 
-## Run Locally with Docker Compose
+### Run Locally with Docker Compose
 
 The first run is very slow.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,28 @@
 version: "3"
 services:
-  hapi-fhir-jpaserver-start:
+  hapi-fhir:
     build: .
-    container_name: hapi-fhir-jpaserver-start
+    image: graphite/hapi-fhir
+    container_name: hapi-fhir
     restart: on-failure
+    depends_on:
+      - fhir-db
     ports:
       - "8080:8080"
-  hapi-fhir-postgres:
-    image: postgres:13-alpine
-    container_name: hapi-fhir-postgres
+    environment:
+      DB_URL: "jdbc:postgresql://fhir-db:5432/hapi"
+      DB_USER: "admin"
+      DB_PASS: "admin"
+      TERMINOLOGY_URL: "https://dev-pivot-app.infra.graphitehealth.io/SymedicaldevpivotFHIRServices/r4/"
+  fhir-db:
+    image: postgres:14.6-alpine
+    container_name: fhir-db
     restart: always
     environment:
       POSTGRES_DB: "hapi"
       POSTGRES_USER: "admin"
       POSTGRES_PASSWORD: "admin"
     volumes:
-      - hapi-fhir-postgres:/var/lib/postgresql/data
+      - hapi-fhir-db:/var/lib/postgresql/data
 volumes:
-  hapi-fhir-postgres:
+  hapi-fhir-db:

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 @Configuration
 @EnableConfigurationProperties
 public class AppProperties {
-
   private Boolean cr_enabled = false;
   private Boolean ips_enabled = false;
   private Boolean openapi_enabled = false;
@@ -57,6 +56,7 @@ public class AppProperties {
   private Long retain_cached_searches_mins = 60L;
   private Long reuse_cached_search_results_millis = 60000L;
   private String server_address = null;
+  private String remote_terminology = null;
   private EncodingEnum default_encoding = EncodingEnum.JSON;
   private FhirVersionEnum fhir_version = FhirVersionEnum.R4;
   private ClientIdStrategyEnum client_id_strategy = ClientIdStrategyEnum.ALPHANUMERIC;
@@ -573,6 +573,14 @@ public class AppProperties {
 
 	public List<String> getLocal_base_urls() {
 		return local_base_urls;
+	}
+
+	public String getRemote_terminology() {
+		return remote_terminology;
+	}
+
+	public void setRemote_terminology(String remote_terminology) {
+		this.remote_terminology = remote_terminology;
 	}
 
 	public static class Cors {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -66,6 +66,7 @@ import ca.uhn.fhir.validation.ResultSeverityEnum;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.hl7.fhir.common.hapi.validation.support.CachingValidationSupport;
+import org.hl7.fhir.common.hapi.validation.support.RemoteTerminologyServiceValidationSupport;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -107,7 +108,17 @@ public class StarterJpaConfig {
 
 	@Primary
 	@Bean
-	public CachingValidationSupport validationSupportChain(JpaValidationSupportChain theJpaValidationSupportChain) {
+	public CachingValidationSupport validationSupportChain(JpaValidationSupportChain theJpaValidationSupportChain, AppProperties appProperties) {
+
+		if(appProperties.getRemote_terminology() != null) {
+			// Add remote terminology server
+			RemoteTerminologyServiceValidationSupport remoteTermSvc = new RemoteTerminologyServiceValidationSupport(theJpaValidationSupportChain.getFhirContext());
+			remoteTermSvc.setBaseUrl(appProperties.getRemote_terminology());
+
+			//It must be first/early in the chain
+			theJpaValidationSupportChain.addValidationSupport(0, remoteTermSvc);
+			ourLog.info("Using remote terminology services");
+		}
 		return ValidationSupportConfigUtil.newCachingValidationSupport(theJpaValidationSupportChain);
 	}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,12 +14,10 @@ spring:
     check-location: false
     baselineOnMigrate: true
   datasource:
-    url: 'jdbc:h2:file:./target/database/h2'
-    #url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
-    max-active: 15
+    url: 'jdbc:postgresql://localhost:5432/hapi'
+    username: admin
+    password: admin
+    driverClassName: org.postgresql.Driver
 
     # database connection pool size
     hikari:
@@ -32,35 +30,32 @@ spring:
       #Hibernate dialect is automatically detected except Postgres and H2.
       #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
       #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
-      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
-  #      hibernate.hbm2ddl.auto: update
-  #      hibernate.jdbc.batch_size: 20
-  #      hibernate.cache.use_query_cache: false
-  #      hibernate.cache.use_second_level_cache: false
-  #      hibernate.cache.use_structured_entries: false
-  #      hibernate.cache.use_minimal_puts: false
+      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+      #      hibernate.hbm2ddl.auto: update
+      #      hibernate.jdbc.batch_size: 20
+      hibernate.cache.use_query_cache: false
+      hibernate.cache.use_second_level_cache: false
+      hibernate.cache.use_structured_entries: false
+      hibernate.cache.use_minimal_puts: false
 
-  ###    These settings will enable fulltext search with lucene or elastic
+      ###    These settings will enable fulltext search with lucene or elastic
       hibernate.search.enabled: true
-  ### lucene parameters
-#      hibernate.search.backend.type: lucene
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
-#      hibernate.search.backend.directory.type: local-filesystem
-#      hibernate.search.backend.directory.root: target/lucenefiles
-#      hibernate.search.backend.lucene_version: lucene_current
+      ### lucene parameters
+      hibernate.search.backend.type: lucene
+      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
+      hibernate.search.backend.directory.type: local-filesystem
+      hibernate.search.backend.directory.root: target/lucenefiles
+      hibernate.search.backend.lucene_version: lucene_current
   ### elastic parameters ===> see also elasticsearch section below <===
 #      hibernate.search.backend.type: elasticsearch
 #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
 hapi:
   fhir:
-
+    remote_terminology: https://dev-pivot-app.infra.graphitehealth.io/SymedicaldevpivotFHIRServices/r4/
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
     fhir_version: R4
-    ### This flag when enabled to true, will avail evaluate measure operations from CR Module.
-    ### Flag is false by default, can be passed as command line argument to override.
-    cr_enabled: "${CR_ENABLED: false}"
     ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
     ### to determine the FHIR server address
     #   use_apache_address_strategy: false
@@ -71,7 +66,7 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
-    #    server_address: http://hapi.fhir.org/baseR4
+    server_address: http://fhir.example.com:8080
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
     ### tells the server whether to attempt to load IG resources that are already present
@@ -104,7 +99,7 @@ hapi:
     #    default_encoding: JSON
     #    default_pretty_print: true
     #    default_page_size: 20
-    #    delete_expunge_enabled: true
+    delete_expunge_enabled: true
     #    enable_repository_validating_interceptor: true
     #    enable_index_missing_fields: false
     #    enable_index_of_type: true
@@ -114,12 +109,12 @@ hapi:
     advanced_lucene_indexing: false
     bulk_export_enabled: false
     bulk_import_enabled: false
-    #    enforce_referential_integrity_on_delete: false
+    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
     #    enforce_referential_integrity_on_delete: false
-    #    enforce_referential_integrity_on_write: false
+    enforce_referential_integrity_on_write: false
     #    etag_support_enabled: true
-    #    expunge_enabled: true
+    expunge_enabled: true
     #    client_id_strategy: ALPHANUMERIC
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true
@@ -142,14 +137,14 @@ hapi:
     search-coord-core-pool-size: 20
     search-coord-max-pool-size: 100
     search-coord-queue-capacity: 200
-    
+
     # comma-separated package names, will be @ComponentScan'ed by Spring to allow for creating custom Spring beans
     #custom-bean-packages:
-    
-    # comma-separated list of fully qualified interceptor classes. 
-    # classes listed here will be fetched from the Spring context when combined with 'custom-bean-packages', 
-    # or will be instantiated via reflection using an no-arg contructor; then registered with the server  
-    #custom-interceptor-classes:  
+
+    # comma-separated list of fully qualified interceptor classes.
+    # classes listed here will be fetched from the Spring context when combined with 'custom-bean-packages',
+    # or will be instantiated via reflection using an no-arg contructor; then registered with the server
+    #custom-interceptor-classes:
 
     # Threadpool size for BATCH'ed GETs in a bundle.
     #    bundle_batch_pool_size: 10
@@ -171,7 +166,7 @@ hapi:
     tester:
       home:
         name: Local Tester
-        server_address: 'http://localhost:8080/fhir'
+        server_address: 'http://fhir.example.com:8000/fhir'
         refuse_to_fetch_third_party_urls: false
         fhir_version: R4
       global:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,9 +14,9 @@ spring:
     check-location: false
     baselineOnMigrate: true
   datasource:
-    url: 'jdbc:postgresql://localhost:5432/hapi'
-    username: admin
-    password: admin
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASS}
     driverClassName: org.postgresql.Driver
 
     # database connection pool size
@@ -51,7 +51,7 @@ spring:
 #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
 hapi:
   fhir:
-    remote_terminology: https://dev-pivot-app.infra.graphitehealth.io/SymedicaldevpivotFHIRServices/r4/
+    remote_terminology: ${TERMINOLOGY_URL}
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5


### PR DESCRIPTION
- Modified the code to use remote terminology services if it's configured
- Updated the basic configuration file for our use case
- Changed docker compose file to easily run locally
- Updated README with Graphite-specific info
- Added build support

I'm treating the `main` branch like we always have, it's the branch that will deploy. There is still a `master` branch. We'll need to keep that to pull changes from the forked repo in the future.